### PR TITLE
Change fail-fast strategy to false for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         elixir: ['1.13']
         otp: ['24']
@@ -127,4 +128,6 @@ jobs:
             priv/plts
           key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
 
-      - run: mix test --trace --slowest 10
+      # - run: mix test --trace --slowest 10
+      - run: mix coveralls
+


### PR DESCRIPTION
- Add `fail-fast` [strategy](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) to `false` to not interrupt CI on the first fail/error.